### PR TITLE
added Edward Ross as committer per GOVERNANCE doc

### DIFF
--- a/COMMITTERS.csv
+++ b/COMMITTERS.csv
@@ -2,3 +2,4 @@ Name, Email, Github ID
 Jelle Wijnja, jelle.wijnja@alliander.com, JelleWijnja
 Robert Steegh, robert.steegh@enexis.nl, RSteegh
 Jasper Aartse Tuijn, jasperat@gmail.com, jasperat
+Edward Ross, edward.ross@gridimp.com, Edward-Ross-Gridimp


### PR DESCRIPTION
Signed-off-by: edward.ross <edward.ross@gridimp.com>

Following invitation and GOVERNANCE document approach, added myself (Edward Ross) as a committer, 