### PR TITLE
Adding four ESDN/Gopacs developers as committers to Shapeshifter

### DIFF
--- a/COMMITTERS.csv
+++ b/COMMITTERS.csv
@@ -5,3 +5,7 @@ Jasper Aartse Tuijn, jasperat@gmail.com, jasperat
 Edward Ross, edward.ross@gridimp.com, Edward-Ross-Gridimp
 Hugo van der Zwaag, hugo@zwaag.io, KoviaX
 Robben Riksen, robben.riksen@alliander.com, RobbenRiksen
+Eelco den Heijer, eelco.denheijer@edsn.nl, eelcodenheijer
+Tom Wetjens, tom.wetjens@edsn.nl, tomwetjens
+Marten Meijboom, marten.meijboom@edsn.nl, MartenMeijboom-EDSN
+Rainer Schreiber, rainer.schreiber@edsn.nl, rainer-schreiber


### PR DESCRIPTION
Signed-off-by: Eelco den Heijer <eelco.denheijer@edsn.nl>
Adding four ESDN/Gopacs developers as committers to Shapeshifter